### PR TITLE
testcase.lisp: Treat :SLYNK like :SWANK

### DIFF
--- a/src/testcase.lisp
+++ b/src/testcase.lisp
@@ -14,7 +14,8 @@
 (in-package #:org.melusina.confidence)
 
 (defparameter *testcase-interactive-p*
-  (and (position :swank *features*) t)
+  (and (or (position :swank *features*)     ;; SLIME
+           (position :slynk *features*) t)) ;; SLY
   "Flag governing the interactive mode of testcases.
 When the flag is a generalised boolean, a failed assertion can be retried. When
 the flag is NIL, the toplevel testcase is exiting the program when done.


### PR DESCRIPTION
`*TESTCASE-INTERACTIVE-P*` now defaults to true if :SLYNK is present in `*FEATURES*`.

This makes SLY behave the same way as SLIME. (SLY is a popular friendly-fork of SLIME.)

(Sorry but I have only tested this change by manually pushing `:SLYNK` to `*FEATURES*` and not by actually running this patch. Beware of potential typos...)