### PR TITLE
Open debugger in situ upon error

### DIFF
--- a/development/testsuite
+++ b/development/testsuite
@@ -38,6 +38,7 @@ testsuite_run()
     testsuite_lisp\
 	--eval "(declaim (optimize safety) (optimize debug))"\
 	--eval "(ql:quickload \"${testsuitesystem}\" :silent t)"\
+	--eval "(org.melusina.confidence:on-assertion-failed-continue)"\
 	--eval "(${testsuitesystem}:$1)"\
 	--eval "(org.melusina.confidence:quit)"
 }

--- a/doc/org.melusina.confidence.texinfo
+++ b/doc/org.melusina.confidence.texinfo
@@ -188,8 +188,10 @@ Defined testcases are automatically exported, which makes it easy to
 call them from the REPL, the testsuite tool or to add them to
 generated documentation.
 
-@include include/var-org.melusina.confidence-star-testcase-interactive-p-star.texinfo
 @include include/macro-org.melusina.confidence-define-testcase.texinfo
+@include include/var-org.melusina.confidence-star-testcase-interaction-mode-star.texinfo
+@include include/fun-org.melusina.confidence-on-assertion-failed-open-debugger-in-situ.texinfo
+@include include/fun-org.melusina.confidence-on-assertion-failed-continue.texinfo             
 
 @node Specialities, , Testcases, Top
 @chapter Specialities

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -22,6 +22,7 @@
    #:testcase-result
    #:record-result
    ;; Testcases
+   #:assertion-failed
    #:define-testcase
    #:without-confidence
    #:*testcase-interactive-p*

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -21,11 +21,14 @@
    #:assertion-condition
    #:testcase-result
    #:record-result
-   ;; Testcases
+   ;; Testcases Interaction Mode
    #:assertion-failed
+   #:on-assertion-failed-open-debugger-in-situ
+   #:on-assertion-failed-continue
+   ;; Testcases
    #:define-testcase
    #:without-confidence
-   #:*testcase-interactive-p*
+   #:*testcase-interaction-mode*
    #:*testsuite-name*
    #:*testsuite-id*
    #:*testsuite-last-result*

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -27,7 +27,7 @@
 (defparameter *alphabet-base64* "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz/-"
   "The set of characters used for base 64 encoding.")
 
-(defun random-string (&optional (length 32) (alphabet *alphabet-base36*))
+(defun random-string (&optional (length 32) (alphabet :base36))
   "Prepare a random alphabetic string of given LENGTH.
 
 The returned string contains LENGTH characters chosen from

--- a/testsuite/testcase.lisp
+++ b/testsuite/testcase.lisp
@@ -18,7 +18,7 @@
 	  nil)
 	(confidence::*current-testcase-result*
 	  nil)
-	(confidence:*testcase-interactive-p* t))
+	(confidence:*testcase-interaction-mode* :batch))
     (funcall (intern "VALIDATE-SUPERVISE-ASSERTION"
 		     (find-package "ORG.MELUSINA.CONFIDENCE/TESTSUITE")))))
 

--- a/testsuite/utilities.lisp
+++ b/testsuite/utilities.lisp
@@ -29,12 +29,22 @@
 (dolist (ensure-macro '(ensure-success ensure-failure ensure-condition))
   (setf (get ensure-macro :org.melusina.confidence/testcase) t))
 
+(defmacro on-assertion-failed/continue (&body body-forms)
+  "Restart function continuing on assertion failed."
+  `(handler-bind
+       ((assertion-failed #'continue))
+     ,@body-forms))
+			 
+  
 (define-testcase ensure-success-1 (result)
   (assert-type result 'assertion-success))
 
 (defmacro ensure-success (form)
   "Ensure that FORM yield an assertion success."
-  `(ensure-success-1 (confidence::supervise-assertion ,(ensure-unwrap form))))
+  `(ensure-success-1
+    (on-assertion-failed/continue
+      (confidence::supervise-assertion
+       ,(ensure-unwrap form)))))
 
 (define-testcase ensure-failure-1 (result &optional description-pattern)
   (assert-type result 'assertion-failure)
@@ -46,7 +56,8 @@
 When DESCRIPTION-PATTERN is provided, it also ensures that the error
 description satisfies this pattern."
   `(ensure-failure-1
-    (confidence::supervise-assertion ,(ensure-unwrap form))
+    (on-assertion-failed/continue
+      (confidence::supervise-assertion ,(ensure-unwrap form)))
     ,description-pattern))
 
 (define-testcase ensure-condition-1 (result &optional condition-type)
@@ -59,7 +70,8 @@ description satisfies this pattern."
 When CONDITION-TYPE is provided, it also ensures that the signalled condition
 has the required type."
   `(ensure-condition-1
-    (confidence::supervise-assertion ,(ensure-unwrap form))
+    (on-assertion-failed/continue
+      (confidence::supervise-assertion ,(ensure-unwrap form)))
     ,condition-type))
 
 

--- a/testsuite/utilities.lisp
+++ b/testsuite/utilities.lisp
@@ -28,23 +28,15 @@
 
 (dolist (ensure-macro '(ensure-success ensure-failure ensure-condition))
   (setf (get ensure-macro :org.melusina.confidence/testcase) t))
-
-(defmacro on-assertion-failed/continue (&body body-forms)
-  "Restart function continuing on assertion failed."
-  `(handler-bind
-       ((assertion-failed #'continue))
-     ,@body-forms))
 			 
-  
 (define-testcase ensure-success-1 (result)
   (assert-type result 'assertion-success))
 
 (defmacro ensure-success (form)
   "Ensure that FORM yield an assertion success."
   `(ensure-success-1
-    (on-assertion-failed/continue
-      (confidence::supervise-assertion
-       ,(ensure-unwrap form)))))
+    (confidence::supervise-assertion
+     ,(ensure-unwrap form))))
 
 (define-testcase ensure-failure-1 (result &optional description-pattern)
   (assert-type result 'assertion-failure)
@@ -56,8 +48,7 @@
 When DESCRIPTION-PATTERN is provided, it also ensures that the error
 description satisfies this pattern."
   `(ensure-failure-1
-    (on-assertion-failed/continue
-      (confidence::supervise-assertion ,(ensure-unwrap form)))
+    (confidence::supervise-assertion ,(ensure-unwrap form))
     ,description-pattern))
 
 (define-testcase ensure-condition-1 (result &optional condition-type)
@@ -70,8 +61,7 @@ description satisfies this pattern."
 When CONDITION-TYPE is provided, it also ensures that the signalled condition
 has the required type."
   `(ensure-condition-1
-    (on-assertion-failed/continue
-      (confidence::supervise-assertion ,(ensure-unwrap form)))
+    (confidence::supervise-assertion ,(ensure-unwrap form))
     ,condition-type))
 
 


### PR DESCRIPTION
Install appropriate restarts around assertion code when supervising their execution.

Introduce *TESTCASE-INTERACTION-MODE* which governs interaction patterns when failures are encountered on an assertion test.

This is to address #4.

@lukego Does this branch make your work with KONS-9 easier?