### PR TITLE
Break into the debugger upon error

### DIFF
--- a/doc/org.melusina.confidence.texinfo
+++ b/doc/org.melusina.confidence.texinfo
@@ -11,7 +11,7 @@
 @end direntry
 
 @copying
-Confidence software and associated documentation is distributed
+@b{Confidence} software and associated documentation is distributed
 under the terms of the MIT License.
 
 @quotation
@@ -112,7 +112,7 @@ function. A special kind of function, but a function.
 * String Assertions::
 * List Assertions::
 * Vector Assertions::
-* Floating Numbers Assertions::
+* Floating Number Assertions::
 @end menu
 
 @node Define Assertions, Basic Assertions, Assertions, Assertions
@@ -169,13 +169,13 @@ function. A special kind of function, but a function.
 @include include/fun-org.melusina.confidence-assert-set-equal.texinfo
 @include include/fun-org.melusina.confidence-assert-subsetp.texinfo
 
-@node Vector Assertions, Floating Numbers Assertions, List Assertions, Assertions
+@node Vector Assertions, Floating Number Assertions, List Assertions, Assertions
 @section Vector Assertions
 
 @include include/fun-org.melusina.confidence-assert-vector-equal.texinfo
 
-@node Floating Numbers Assertions, Testcases, Vector Assertions, Assertions
-@section Floating Numbers Assertions
+@node Floating Number Assertions, Testcases, Vector Assertions, Assertions
+@section Floating Number Assertions
 
 @include include/var-org.melusina.confidence-star-double-float-precision-star.texinfo
 @include include/var-org.melusina.confidence-star-single-float-precision-star.texinfo
@@ -184,24 +184,80 @@ function. A special kind of function, but a function.
 @include include/fun-org.melusina.confidence-assert-float-is-definitely-greater-than.texinfo
 @include include/fun-org.melusina.confidence-assert-float-is-definitely-less-than.texinfo
 
-@node Testcases, Specialities, Floating Numbers Assertions, Top
+@node Testcases, Specialities, Floating Number Assertions, Top
 @chapter Testcases
 
-The @i{define-testcase} macro allows to define testcases, which are
-functions specially crafted to run tests.  There are two differences
-with regular functions. The first difference is that calls to
-testcases and assertions in a testcase are instrumented, so that a
-global success report is produced. The second difference is that when
-a testcase is run as a toplevel form in a batch environment (not at a
-REPL) the testcase prints a summary of results when done and exits the
-program with a success status reflecting the testcase result.
+The @i{define-testcase} macro allows to define @i{testcases}, which
+are functions specially crafted to run @i{assertions} and build a
+testsuite.  There are three important differences with regular
+functions. The first one is that calls to assertions in a testcase are
+instrumented, so that a global success report is produced. The second
+difference is that when a testcase is run as a toplevel form the
+testcase prints a summary of results when done. The third difference
+is that some specific @i{restarts} are available in this context.
+
+@section Define a Testcase
+
+@include include/macro-org.melusina.confidence-define-testcase.texinfo
+@include include/class-org.melusina.confidence-testcase-outcome.texinfo
+
+@section Describe Failed Assertions
+
+When an assertion fails, it prints a description on the
+@code{*error-output*}, unless the following configuration variable
+is set to @code{nil}.
+
+@include include/var-org.melusina.confidence-star-testcase-describe-failed-assertions-star.texinfo
+
+
+@section Run Testcases in Batch
+
+The @b{Confidence} system normally runs test cases in batch, which is
+appropriate when it is used for fully automated tests, in continuous
+integration and delivery pipelines.
+
+@section Run Testcases Interactively
+
+The @b{Confidence} system can be configured so that when a testcase
+meets an unexpected condition, such as an error or an unsatisfied
+assertion, the debugger is invoked. To do so, modify the variable
+@code{*testcase-break-into-the-debugger-on-errors*} either directly
+or with the function @code{testcase-break-into-the-debugger-on-errors}.
+
+@include include/var-org.melusina.confidence-star-testcase-break-into-the-debugger-on-errors-star.texinfo
+@include include/fun-org.melusina.confidence-testcase-break-into-the-debugger-on-errors.texinfo
+
+When this configuration is active, the following @i{restarts} are
+available in the debugger:
+
+@itemize
+@item
+@b{ASSERTION-RETRY} Which retries to evaluate the arguments of the
+failing assertion and the assertion itself.
+@item
+@b{TESTCASE-RETRY} Which retries the current testcase.
+@item
+@b{TESTCASE-CONTINUE} Which registers an error and continues the
+current testcase.
+@item
+@b{TESTCASE-RETURN} Which registers an error and immediately returns
+from the current testcase.
+@item
+@b{TESTCASE-STEP-UP} Which registers an error and continue the current
+testcase without breaking into the debugger.
+@item
+@b{TESTCASE-SCROLL} Which registers an error and continue the current
+testcase and other testcases higher in the call stack without breaking
+into the debugger.
+@end itemize
+
+@section Add Testcases to the Export List of a Package
 
 Defined testcases are automatically exported, which makes it easy to
 call them from the REPL, the testsuite tool or to add them to
 generated documentation.
 
-@include include/var-org.melusina.confidence-star-testcase-interactive-p-star.texinfo
-@include include/macro-org.melusina.confidence-define-testcase.texinfo
+XXXX
 
 @node Specialities, , Testcases, Top
 @chapter Specialities

--- a/doc/org.melusina.confidence.texinfo
+++ b/doc/org.melusina.confidence.texinfo
@@ -106,7 +106,7 @@ function. A special kind of function, but a function.
 
 @menu
 * Define Assertions::
-* Basic Assertions::
+* Comparison Assertions::
 * Condition Assertions::
 * Character Assertions::
 * String Assertions::
@@ -115,12 +115,12 @@ function. A special kind of function, but a function.
 * Floating Number Assertions::
 @end menu
 
-@node Define Assertions, Basic Assertions, Assertions, Assertions
+@node Define Assertions, Comparison Assertions, Assertions, Assertions
 @section Define Assertions
 @include include/macro-org.melusina.confidence-define-assertion.texinfo
 
-@node Basic Assertions, Condition Assertions, Define Assertions, Assertions
-@section Basic Assertions
+@node Comparison Assertions, Condition Assertions, Define Assertions, Assertions
+@section Comparison Assertions
 
 @include include/fun-org.melusina.confidence-assert-t.texinfo
 @include include/fun-org.melusina.confidence-assert-t-star.texinfo
@@ -136,7 +136,7 @@ function. A special kind of function, but a function.
 @include include/fun-org.melusina.confidence-assert-lt-equals.texinfo
 @include include/fun-org.melusina.confidence-assert-gt-equals.texinfo
 
-@node Condition Assertions, Character Assertions, Basic Assertions, Assertions
+@node Condition Assertions, Character Assertions, Comparison Assertions, Assertions
 @section Condition Assertions
 
 @include include/macro-org.melusina.confidence-assert-condition.texinfo
@@ -255,9 +255,12 @@ into the debugger.
 
 Defined testcases are automatically exported, which makes it easy to
 call them from the REPL, the testsuite tool or to add them to
-generated documentation.
+generated documentation.  It could however be desirable to explciitly
+add them to the export list of a package.  To support this, the
+@b{Confidence} system exports the following function:
 
-XXXX
+@include include/fun-org.melusina.confidence-print-export-list-for-testcases.texinfo
+
 
 @node Specialities, , Testcases, Top
 @chapter Specialities
@@ -274,7 +277,7 @@ test resources is just working as expected.
 
 It is simple enough to define a with-macro in Common Lisp so that
 @b{Confidence} does not provide an extra feature to do so. Just mind
-the `unwind-protect` operator.
+the @code{unwind-protect} operator.
 
 
 @section Test Hierarchies
@@ -296,24 +299,21 @@ functional tests journeys, adding fixtures to the defined testsuite.
 Having a testcase explicitly listing the other testcases it must run
 is a simple and reliable organisation that never lies to the
 programmer.  It also makes the test hierarchy navigable in IDEs
-without extra tooling, which is a good thing.
+without supplementary tooling.
 
 
 @section Test Tags
 
 Some test frameworks provide a tag feature so that it possible to run
-tests according to some tags attached to them.
-
-Using tags to decorate tests that need to be run in such or such
-context, similarly to what popular Java test frameworks propose,
-obfuscates the test workflow and nobody wants to discover after
-several weeks of operation that some tests were not run by the
-deployment pipeline.
+tests according to some tags attached to them.  Some popular Java
+testing frameworks offer such a tag feature. Relying on this to decide
+which tests to run obfuscates the test workflow and makes it hard to
+understand which tests are run in a specific context.
 
 Having a testcase explicitly listing the other testcases it must run
 is a simple and reliable organisation that never lies to the
 programmer.  It also makes the test hierarchy navigable in IDEs
-without extra tooling, which is a good thing.
+without extra tooling.
 
 
 @section Test Selection
@@ -321,6 +321,8 @@ without extra tooling, which is a good thing.
 When some tests are only relevant to some platform, or must be be
 controlled by a feature, it is very easy to control their inclusion in
 the testsuite using the feature-related reader macros.  It does not
-seem necessary for @b{Confidence} to provide extra tools here.
+seem necessary for @b{Confidence} to provide special features as the
+usual Common Lisp operstors @code{when}, @code{unless} and
+@code{return-from} can be used here.
 
 @bye

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -23,6 +23,7 @@
    #:testcase-success
    #:testcase-failure
    #:testcase-condition
+   #:testcase-argument-values
    ;; Testcases
    #:assertion-path
    #:assertion-name
@@ -40,6 +41,8 @@
    #:*testsuite-id*
    #:*testsuite-last-result*
    #:list-testcases
+   #:testcase-break-into-the-debugger-on-errors
+   #:*testcase-break-into-the-debugger-on-errors*
    ;; Assertions
    #:define-assertion
    #:list-assertions

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -40,9 +40,10 @@
    #:*testsuite-name*
    #:*testsuite-id*
    #:*testsuite-last-result*
-   #:list-testcases
-   #:testcase-break-into-the-debugger-on-errors
    #:*testcase-break-into-the-debugger-on-errors*
+   #:testcase-break-into-the-debugger-on-errors
+   #:list-testcases
+   #:print-export-list-for-testcases
    ;; Assertions
    #:define-assertion
    #:list-assertions

--- a/src/testcase.lisp
+++ b/src/testcase.lisp
@@ -43,7 +43,7 @@ Usually TESTSUITE but commonly used values are ACCEPTANCE, INTEGRATION, PREFLIGH
 (defparameter *testsuite-id* nil
   "A unique identfier for the current testsuite run batch.")
 
-(defparameter *last-testsuite-result* nil
+(defvar *last-testsuite-result* nil
   "The results of the last testsuite that ran.")
 
 

--- a/src/testcase.lisp
+++ b/src/testcase.lisp
@@ -639,11 +639,17 @@ of tests that ran and their outcomes."
        (export (quote ,testcase-name))
        (set-testcase-properties ',testcase-name))))
 
-(defun list-testcases (&optional package-designator)
+(defun list-testcases (&optional (package-designator *package*))
   "List testcases exported by PACKAGE-DESIGNATOR."
   (loop :for s :being :the :external-symbols :of (find-package package-designator)
 	:when (get s :org.melusina.confidence/testcase)
-	:collect s))
+	:collect s :into testcases
+	:finally (return (sort testcases #'string< :key #'symbol-name))))
+
+(defun print-export-list-for-testcases (&optional (package-designator *package*))
+  "Print a form suitable for exporting TESTCASES defiend by PACKAGE-DESIGNATOR."
+  (loop :for testcase :in (list-testcases package-designator)
+	:do (format t "~&   #:~A~%" (string-downcase (symbol-name testcase)))))
 
 (defun quit ()
   "Quit the SBCL lisp image and set exit status accordingly."

--- a/src/testcase.lisp
+++ b/src/testcase.lisp
@@ -307,10 +307,10 @@ instead of returning normally."))
 
 
 ;;;
-;;; SUPERVISE-ASSERTION
+;;; INSTRUMENT-ASSERTION
 ;;;
 
-(defun supervise-assertion-1 (&key name form type argument-names argument-lambdas assertion-lambda)
+(defun instrument-assertion-1 (&key name form type argument-names argument-lambdas assertion-lambda)
   "Supervise the execution of ARGUMENTS-LAMBDA and ASSERTION-LAMBDA."
   (labels ((evaluation-strategy-1 (argument-condition argument-values)
 	     (when argument-condition
@@ -367,8 +367,8 @@ instead of returning normally."))
 	     (evaluation-strategy (mapcar #'supervise-evaluation-1 argument-lambdas))))
     (supervise-evaluation argument-lambdas)))
 
-(defmacro supervise-assertion (form)
-  "Supervise the execution of the assertion FORM and return ASSERTION evaluation details.
+(defmacro instrument-assertion (form)
+  "Instrument the execution of the assertion FORM and return ASSERTION evaluation details.
 This makes sure that the returned type for FORM is an instance of RESULT and
 guarantees that conditions triggered by the evaluation of arguments are recorded."
   (let* ((name
@@ -390,7 +390,7 @@ guarantees that conditions triggered by the evaluation of arguments are recorded
 	      `(lambda (argv) (declare (ignore argv)) ,form))
 	     (:function
 	      `(lambda (argv) (apply (function ,name) argv))))))
-    `(supervise-assertion-1
+    `(instrument-assertion-1
       :name (quote ,name)
       :form (quote ,form)
       :type ,type
@@ -442,7 +442,7 @@ symbol of this function."
 	   ((eq 'without-confidence (is-funcall-p form))
 	    `(progn ,@(rest form)))
 	   ((is-assert-form-p form)
-            `(supervise-assertion ,form))
+            `(instrument-assertion ,form))
            ((is-funcall-p form)
             (cons (first form) (mapcar #'wrap-assertion-forms (rest form))))
            (t

--- a/testsuite/package.lisp
+++ b/testsuite/package.lisp
@@ -15,8 +15,39 @@
   (:local-nicknames (#:confidence #:org.melusina.confidence))
   (:use #:common-lisp #:org.melusina.confidence)
   (:export
-   #:list-available-tests
-  ))
+   #:a-compound-failing-testsuite
+   #:a-failing-argument-testsuite
+   #:a-failing-testcase-testsuite
+   #:a-simple-failure
+   #:a-successful-testsuite
+   #:a-successful-testsuite-with-function-calls
+   #:ensure-that-define-testcase-recognises-sharpsign-single-quote-in-function-names
+   #:ensure-that-testcase-is-reported-when-wrapped-in-flet
+   #:interactive-assertion-count
+   #:interactive-testcase-extensivity
+   #:interactive-testcase-extensivity-1
+   #:interactive-testcase-extensivity-2
+   #:perform-many-assertions
+   #:perform-many-assertions-wrapped-with-flet
+   #:run-all-tests
+   #:run-interactive-tests
+   #:testsuite-assert-char*
+   #:testsuite-assert-condition
+   #:testsuite-assert-float*
+   #:testsuite-assert-list*
+   #:testsuite-assert-string*
+   #:testsuite-assert-vector*
+   #:testsuite-assertion
+   #:testsuite-basic-assertions
+   #:testsuite-define-assertion
+   #:testsuite-list-as-set
+   #:testsuite-result
+   #:testsuite-string-match
+   #:testsuite-testcase
+   #:testsuite-utilities
+   #:validate-define-testcase
+   #:validate-outcome-can-be-described
+   #:validate-supervise-assertion))
 
 (in-package #:org.melusina.confidence/testsuite)
 

--- a/testsuite/testcase.lisp
+++ b/testsuite/testcase.lisp
@@ -36,14 +36,21 @@
   (assert-t t))
 
 (define-testcase a-failing-argument-testsuite ()
-  (assert-t nil)
-  (assert-eq 0 (+ 1 1))
-  (assert-t (error "An intentional error")))
+  (assert-t t)
+  (assert-eq 0 0)
+  (assert-t (error "An intentional error occuring when evaluating assertion arguments.")))
 
 (define-testcase a-failing-testcase-testsuite ()
-  (error "An intentional error")
-  (assert-t nil)
-  (assert-eq 0 (+ 1 1)))
+  (assert-t t)
+  (assert-eq 0 0)
+  (error "An intentional error occuring in the testsuite."))
+
+(define-testcase a-compound-failing-testsuite ()
+  (a-successful-testsuite)
+  (a-successful-testsuite)
+  (a-failing-argument-testsuite)
+  (a-failing-argument-testsuite)
+  (a-failing-testcase-testsuite))
 
 (define-testcase a-successful-testsuite-with-function-calls ()
   (funcall 'a-successful-testsuite)

--- a/testsuite/utilities.lisp
+++ b/testsuite/utilities.lisp
@@ -15,7 +15,7 @@
 
 (defun ensure-unwrap (form)
   (if (and (eq 2 (length form))
-	   (eq 'confidence::supervise-assertion (first form)))
+	   (eq 'confidence::instrument-assertion (first form)))
       (second form)
       form))
 


### PR DESCRIPTION
This PR allows to open a debugger when unexpected errors occur in the testsuite.

Use a call to `(testcase-break-into-the-debugger-on-errors)` to arrange for this to happen. When this configuration is active, the following restarts are available in the debugger:
• ASSERTION-RETRY Which retries to evaluate the arguments of the failing assertion
and the assertion itself.
• TESTCASE-RETRY Which retries the current testcase.
• TESTCASE-CONTINUE Which registers an error and continues the current testcase.
• TESTCASE-RETURN Which registers an error and immediately returns from the current testcase.
• TESTCASE-STEP-UPWhichregistersanerrorandcontinuethecurrenttestcasewith- out breaking into the debugger.
• TESTCASE-SCROLL Which registers an error and continue the current testcase and other testcases higher in the call stack without breaking into the debugger.

The testsuites `a-failing-argument-testsuite`, `a-failing-testcase-testsuite` and `a-compound-failing-testsuite` can be used to experiment with this as in:

~~~
(ql:quickload '#:org.melusina.confidence/user)
(in-package #:org.melusina.confidence/user)
(confidence:testcase-break-into-the-debugger-on-errors)
(testsuite:a-compound-failing-testsuite)
~~~


This solves #4 opened by @lukego